### PR TITLE
Test: exercise the visual-diff pipeline

### DIFF
--- a/lak-typst/1n.typ
+++ b/lak-typst/1n.typ
@@ -3,7 +3,7 @@
 == 1#N— <sec:1N>
 
 #bt(```
-  2C        _Stayman_ { below INV, short C / *5M, INV / 4M, INV+ / *54 or 64 MM, INV+ }
+  2C        _Stayman_ { below INV, short C / *5M, INV, may have 4+m / 4M, INV+, denies 5M / *54 or 64 MM, INV+ }
     2D>1N2C2D   no 4+M
     2H>1N2C2H   4--5H, may have 4S
     2S>1N2C2S   4--5S, no 4H

--- a/lak-typst/2c.typ
+++ b/lak-typst/2c.typ
@@ -15,13 +15,16 @@
 * 3CDH      11+, 6+ cards in the next higher suit, INV+
     transfer   decline INV (even with singleton)
     other      accept INV
-* 3S        6S 4H GF
+* 3S        6S 4H, GF, better than a direct 4S
   3N        to play
   4C        5-9, preemptive, at least 3C usually 4C
   4H        to play
-  4S        to play
+  4N        RKC for clubs
   5C        to play
 ```)
+
+If the opening bid is doubled, a redouble shows a good club suit and asks
+partner to pass any further action from the opponents for penalty.
 
 === 2#C—2#D— <2C2D>
 

--- a/lak-typst/2h.typ
+++ b/lak-typst/2h.typ
@@ -2,13 +2,15 @@
 
 == 2#H— <sec:2H>
 
-Assume 6#plus#H unless NV vs. VUL.
+This is a strong single-suited hand. Responder should assume a 6#plus#H suit
+unless the vulnerability is favourable, in which case a lighter 5-card suit
+is possible.
 
 #bt(```
   2S   14+, 5+S, F1
   2N   14+, asks
     = (bid)
-      * step 1   PASS
+      * step 1   PASS or 5-card suit
         step 2   DBL/RDBL
         step *   next bids
     3C   MIN, bad suit
@@ -17,8 +19,9 @@ Assume 6#plus#H unless NV vs. VUL.
     3S   MAX, good suit
   3C   14+, 5+C, F1
   3D   14+, 5+D, F1
-  3H   0-13, 3+H, preempt
+  3N   asks for a stopper, GF
   4H   to play
+  4N   quantitative
 ```)
 
 /* Commented-out alternative from the original LaTeX source (2h.tex):


### PR DESCRIPTION
Throwaway draft to visually verify the PR visual-diff workflow against real, varied content — not meant to merge.

Covers:
- Added/deleted/modified prose (a sentence swap in `2h.typ`, a new paragraph in `2c.typ`)
- Added/deleted/modified `#bt` rows, including inside a `followups` sub-table
- A modified `dcases` alternative mixing a highlighted (`* `) and a non-highlighted change in the same row (`1n.typ`'s Stayman brace)