### PR TITLE
Format and fix typst 

### DIFF
--- a/.github/workflows/typst-pr-diff.yaml
+++ b/.github/workflows/typst-pr-diff.yaml
@@ -80,25 +80,33 @@ jobs:
             done
           fi
 
-      # Inline images, pushed to a per-PR scratch branch and embedded via
+      # Inline images, pushed to a per-PR scratch ref and embedded via
       # raw.githubusercontent.com so they render directly in the PR
       # conversation — wrapped in a single collapsed <details> block, since a
       # multi-page diff would otherwise dominate the conversation. The blank
       # lines right after <summary> and before </details> are required for
       # GitHub to render the markdown image syntax inside the HTML block
       # instead of showing it as literal text.
-      - name: Push diff images to scratch branch
+      #
+      # The ref lives outside refs/heads/ (and refs/tags/) so it never shows
+      # up as a branch or tag in the GitHub UI, doesn't interact with branch
+      # protection, and isn't picked up by branch-triggered workflows. Both
+      # raw.githubusercontent.com and the github.com /raw/ redirect resolve
+      # any full ref path this way — the same mechanism GitHub uses to serve
+      # refs/pull/N/head.
+      - name: Push diff images to scratch ref
         if: steps.diff.outputs.changed == 'true'
         id: scratch
         run: |
-          branch="typst-pr-diff-images/${{ github.event.pull_request.number }}"
+          ref="refs/typst-diff-images/${{ github.event.pull_request.number }}"
+          local_branch="typst-pr-diff-images-tmp"
           dir="$(mktemp -d)"
-          git worktree add --orphan -b "$branch" "$dir"
+          git worktree add --orphan -b "$local_branch" "$dir"
           cp /tmp/diffpages/*.png "$dir"/
           git -C "$dir" add .
           git -C "$dir" -c user.name="github-actions[bot]" -c user.email="github-actions[bot]@users.noreply.github.com" \
             commit -m "Typst PR diff images for #${{ github.event.pull_request.number }}"
-          git -C "$dir" push --force origin "$branch"
+          git -C "$dir" push --force origin "refs/heads/$local_branch:$ref"
           {
             echo "message<<EOF"
             echo "<details>"
@@ -106,7 +114,7 @@ jobs:
             echo
             for p in /tmp/diffpages/*.png; do
               name="$(basename "$p")"
-              url="${{ github.server_url }}/${{ github.repository }}/raw/${branch}/${name}"
+              url="${{ github.server_url }}/${{ github.repository }}/raw/${ref}/${name}"
               echo "![${name}](${url})"
               echo
             done

--- a/.github/workflows/typst-pr-diff.yaml
+++ b/.github/workflows/typst-pr-diff.yaml
@@ -90,10 +90,12 @@ jobs:
       #
       # The ref lives outside refs/heads/ (and refs/tags/) so it never shows
       # up as a branch or tag in the GitHub UI, doesn't interact with branch
-      # protection, and isn't picked up by branch-triggered workflows. Both
-      # raw.githubusercontent.com and the github.com /raw/ redirect resolve
-      # any full ref path this way — the same mechanism GitHub uses to serve
-      # refs/pull/N/head.
+      # protection, and isn't picked up by branch-triggered workflows.
+      # raw.githubusercontent.com resolves any full ref path this way — the
+      # same mechanism GitHub uses to serve refs/pull/N/head. The
+      # github.com/OWNER/REPO/raw/REF/PATH redirector does NOT: it 404s for
+      # any ref outside refs/heads/ (verified against refs/pull/N/head too),
+      # so URLs must hit raw.githubusercontent.com directly, not that shortcut.
       - name: Push diff images to scratch ref
         if: steps.diff.outputs.changed == 'true'
         id: scratch
@@ -114,7 +116,7 @@ jobs:
             echo
             for p in /tmp/diffpages/*.png; do
               name="$(basename "$p")"
-              url="${{ github.server_url }}/${{ github.repository }}/raw/${ref}/${name}"
+              url="https://raw.githubusercontent.com/${{ github.repository }}/${ref}/${name}"
               echo "![${name}](${url})"
               echo
             done

--- a/lak-typst/1c.typ
+++ b/lak-typst/1c.typ
@@ -305,7 +305,7 @@ If GF is established, further doubles are for penalty.
 
 #bt(```
 * PASS       0-6 (bad 7) or trap
-    * DBL   takeout
+*     DBL   takeout
 * DBL        7+, no suit to bid below 3N, GF
   3N         to play usually, with stopper
   new suit   5+ cards, GF

--- a/lak-typst/1c.typ
+++ b/lak-typst/1c.typ
@@ -280,7 +280,7 @@ If GF is established, further doubles are for penalty.
 #bt(```
 * PASS                0-5 or trap
   DBL                 { 6-7 = always / *8+, BAL, without stopper, GF (cue later to reveal) = over 2X }
-    = over 1X
+    over 1X
       PASS        penalty
       1M          4+M, F1
       1N>sec:1N   17-18 (18-19), BAL, with stopper, system on, NF

--- a/lak-typst/1d.typ
+++ b/lak-typst/1d.typ
@@ -43,25 +43,25 @@ As a responder assume that opener has 10--13(14) BAL until told otherwise.
   (DBL)
     PASS   denies 3+H, may have 4S if BAL/3-suiter
     RDBL   3H
-*   1S   4S
-    1N     1--2 H
-*   2C   54+mm
+*   1S     4S
+*   1N     1--2 H
+*   2C     54+mm
   (1S)
     PASS   denies 3H
     DBL    3H
     1N     1--2H, good stops
-  * 2C   54+mm
+*   2C     54+mm
   (1N nat)
     DBL   12-15, 3H
-  * 2C   54+mm
+*   2C    54+mm
   (2C)
     DBL   3H
   (2D)
     DBL   3H
   (2S)
     DBL   12-15, 3H
-*   2N   good hand with 6D and stopper, NF
-*   3C   55+mm
+*   2N    good hand with 6D and stopper, NF
+*   3C    55+mm
   1S   4S, other bids deny 4S
     `*`   [XYZ](XYZ)
   1N   10-13(14), no singleton, BAL
@@ -84,23 +84,23 @@ As a responder assume that opener has 10--13(14) BAL until told otherwise.
     PASS   denies 3+S
     RDBL   3S
     1N     1--2 S
-    * 2C   54+mm
+*     2C   54+mm
   (1N nat)
     DBL   12-15, 3S
-    * 2C   54+mm
+*     2C   54+mm
   (2C)
     DBL   3S
   (2D)
     DBL   3S
   (2H)
     DBL   12-15, 3S
-    * 2N   good hand with 6D and stopper, NF
-    * 3C   55+mm
+*     2N   good hand with 6D and stopper, NF
+*     3C   55+mm
   1N   10-13(14), no singleton, BAL
     `*`   [XYZ](XYZ)
   2C   8+ cards in the minors, not 6D 4C
   2D   6+D
-    * 2H   artificial GF
+*     2H   artificial GF
 * 2H   5H 6+D
   2S   { 10-13(14), 4S, BAL / 10-12, 4S, unBAL / *3451 }
 * 2N   13-15, 3S 6+D, BAL

--- a/lak-typst/1d.typ
+++ b/lak-typst/1d.typ
@@ -40,35 +40,35 @@ As a responder assume that opener has 10--13(14) BAL until told otherwise.
 === 1#D—1#H— <1D1H>
 
 #bt(```
-  = (DBL)
+  (DBL)
     PASS   denies 3+H, may have 4S if BAL/3-suiter
     RDBL   3H
-    * 1S   4S
+*   1S   4S
     1N     1--2 H
-    * 2C   54+mm
-  = (1S)
+*   2C   54+mm
+  (1S)
     PASS   denies 3H
     DBL    3H
     1N     1--2H, good stops
-    * 2C   54+mm
-  = (1N nat)
+  * 2C   54+mm
+  (1N nat)
     DBL   12-15, 3H
-    * 2C   54+mm
-  = (2C)
+  * 2C   54+mm
+  (2C)
     DBL   3H
-  = (2D)
+  (2D)
     DBL   3H
-  = (2S)
+  (2S)
     DBL   12-15, 3H
-    * 2N   good hand with 6D and stopper, NF
-    * 3C   55+mm
+*   2N   good hand with 6D and stopper, NF
+*   3C   55+mm
   1S   4S, other bids deny 4S
     `*`   [XYZ](XYZ)
   1N   10-13(14), no singleton, BAL
     `*`   [XYZ](XYZ)
   2C   8+ cards in the minors, not 6D 4C
   2D   10-12, 6+D
-    * 2S   artificial GF
+*   2S   artificial GF
   2H   { 10-13(14), 4H, BAL / 10-12, 4H, unBAL }
 * 2S   5S 6+D
 * 2N   13-15, 3H 6+D
@@ -80,19 +80,19 @@ As a responder assume that opener has 10--13(14) BAL until told otherwise.
 === 1#D—1#S— <1D1S>
 
 #bt(```
-  = (DBL)
+  (DBL)
     PASS   denies 3+S
     RDBL   3S
     1N     1--2 S
     * 2C   54+mm
-  = (1N nat)
+  (1N nat)
     DBL   12-15, 3S
     * 2C   54+mm
-  = (2C)
+  (2C)
     DBL   3S
-  = (2D)
+  (2D)
     DBL   3S
-  = (2H)
+  (2H)
     DBL   12-15, 3S
     * 2N   good hand with 6D and stopper, NF
     * 3C   55+mm
@@ -164,10 +164,10 @@ Same as #link(<sec:v1N>)[against 1#N].
 === 1#D—1#N— <1D1N>
 
 #bt(```
-  = (DBL)
+  (DBL)
     2C   44+ mm, unBAL
     2D   5+D
-  = (2M)
+  (2M)
     DBL   takeout
     2N    good 3D rebid
     3C    4/5D 5C
@@ -182,7 +182,7 @@ Same as #link(<sec:v1N>)[against 1#N].
 === 1#D—2#C— <1D2C>
 
 #bt(```
-  = (2M)
+  (2M)
     PASS   waiting
     DBL    penalty
     2N     good stops
@@ -222,7 +222,7 @@ Same as #link(<sec:v1N>)[against 1#N].
 === 1#D—2#D— <1D2D>
 
 #bt(```
-  = (2M)
+  (2M)
     3D   D fit, BAL, MIN
     3M   4+D, short M
   2H   10-13(14), BAL

--- a/lak-typst/1h.typ
+++ b/lak-typst/1h.typ
@@ -3,19 +3,19 @@
 == 1#H— <sec:1H>
 
 #bt(```
-  1S   7+, 4+S, F1
-  1N   7-11, no H fit
-  2m   11+, 5+m, no H fit
-  2H   5-9, 3+H
-* 2N   11-12 or 17+, 3+H, F3H
-    * 3m      4+m, F1
-      3H      MIN, no side suit
-      3S/4m   MAX, splinter
-      3N      MAX, 5H(332)
-      4H      MAX, 6H(322) or 7H(222)
-  3H   0-5, 4+H
-  3N   13-16, no H fit, BAL
-  4H   13-16, 3+H
+  1S      7+, 4+S, F1
+  1N      7-11, no H fit
+  2m      11+, 5+m, no H fit
+  2H      5-9, 3+H
+* 2N      11-12 or 17+, 3+H, F3H
+*   3m      4+m, F1
+*   3H      MIN, no side suit
+*   3S/4m   MAX, splinter
+*   3N      MAX, 5H(332)
+*   4H      MAX, 6H(322) or 7H(222)
+  3H      0-5, 4+H
+  3N      13-16, no H fit, BAL
+  4H      13-16, 3+H
 ```)
 
 === 1#H—(2#N minors)— <sec:1M-2N>
@@ -28,7 +28,7 @@
   3S    nat, NF
 ```)
 
-/* Commented-out alternatives from the original LaTeX source (1h.tex): 
+/* Commented-out alternatives from the original LaTeX source (1h.tex):
 Alternative structure idea that we currently do not use:
 
 === 1#H— <sec:1H-alt>

--- a/lak-typst/1h.typ
+++ b/lak-typst/1h.typ
@@ -76,7 +76,7 @@ Alternative structure idea that we currently do not use:
 === 1#H—1#N— <1H1N>
 
 #bt(```
-  = (bid)
+  (bid)
     X   takeout
   PASS   10-13, { BAL / 4S 5H, no 4m }
   2C     4+C
@@ -92,7 +92,7 @@ Alternative structure idea that we currently do not use:
 === 1#H—2#C— <1H2C>
 
 #bt(```
-  = (bid)
+  (bid)
     X       penalty
     3C      3C, unBAL
     3 cue   4+C, shortness in opp's suit
@@ -123,7 +123,7 @@ Alternative structure idea that we currently do not use:
 === 1#H—2#N— <1H2N>
 
 #bt(```
-  = (bid)
+  (bid)
     X      shortness in their suit
     PASS   waiting
   3C       10-13

--- a/lak-typst/1n.typ
+++ b/lak-typst/1n.typ
@@ -45,7 +45,7 @@
 
 /* Commented-out alternative followups / annotations from the LaTeX source (1n.tex):
 #bt(```
-  = followups for 2S (5S, INV)
+  followups for 2S (5S, INV)
     PASS   declines
     2N     accepts, 2S
       PASS   BAL, mild invite
@@ -53,21 +53,21 @@
       3N     to play
     3S     3S, MIN
     4S     3S, MAX
-  = followups for 2N (INV, may have 5H)
+  followups for 2N (INV, may have 5H)
     3m   6 cards, to play
-  = followups for 3C (5+C 4M, GF)
+  followups for 3C (5+C 4M, GF)
     3D   R for LMH short
     3M   noise with C interest
     3N   no interest
-  = followups for 3D (5+D 4M, GF)
+  followups for 3D (5+D 4M, GF)
     3M   noise with D interest
     3N   no interest
-  = followups for 3H (5S 4H, GF)
+  followups for 3H (5S 4H, GF)
     3S   2S 3H
     3N   to play
     4C   good S raise
     4S   bad S raise
-  = followups for 3S (5H 4S, GF)
+  followups for 3S (5H 4S, GF)
     4C   good H raise
     4H   bad H raise
 ```)
@@ -93,13 +93,13 @@
 
 /* Commented followups from the LaTeX source (1n.tex):
 #bt(```
-  = followups for 3C (4S 5+C, GF)
+  followups for 3C (4S 5+C, GF)
     3D   C interest, asks LH short
     3H   5H
       3S   waiting, no fit or no D stop
     3S   S flag, asks LH short
     4C   great hand for C
-  = followups for 3D (4S 5+D, GF)
+  followups for 3D (4S 5+D, GF)
     3H   5H
       3S   waiting, no fit or no C stop
     3S   S flag, asks LH short
@@ -125,12 +125,12 @@
 
 /* Commented followups from the LaTeX source (1n.tex):
 #bt(```
-  = followups for 3C (4H 5+C, GF)
+  followups for 3C (4H 5+C, GF)
     3D   C interest, asks LH short
     3H   4H, asks LH short
     3S   5S
     4C   great hand for C
-  = followups for 3D (4H 5+D, GF)
+  followups for 3D (4H 5+D, GF)
     3H   relay with some D interest, asks LH short
     3S   5S
     4m   great hand for D
@@ -175,7 +175,7 @@
 /* Commented followups from the LaTeX source (1n.tex); these were for 3C (as 2N)
    and 3D (as 3C):
 #bt(```
-  = followups for 3C (4+C, GF; written when this bid was 2N)
+  followups for 3C (4+C, GF; written when this bid was 2N)
     3C   no H fit
       3D      short D
       3H      short S
@@ -187,7 +187,7 @@
       3N 4C   LH singleton, ST
       4H      to play
     3N   values in other suits, usually 2H 3C
-  = followups for 3D (4+D, GF; written when this bid was 3C)
+  followups for 3D (4+D, GF; written when this bid was 3C)
     3D   no H fit
       3H      short C
       3S      short S
@@ -224,7 +224,7 @@
 
 /* Commented followups from the LaTeX source (1n.tex), for 2C (as 3C) and 3D (as 3D):
 #bt(```
-  = followups for 2C (4+C, GF; written when this bid was 3C)
+  followups for 2C (4+C, GF; written when this bid was 3C)
     3C   no S fit
       3D      short D
       3H      short H
@@ -236,7 +236,7 @@
       3N 4C   LH singleton, ST
       4S      to play
     3N   values in other suits, usually 2S 3C
-  = followups for 3D (4+D, GF)
+  followups for 3D (4+D, GF)
     3D   no H fit
       3H    short C
       3S    short H
@@ -310,9 +310,9 @@
 === 1#N—(2#C)—
 
 #bt(```
-  = if MM
+  if MM
     `*`   natural
-  = else
+  else
     DBL   _Stayman_
     `*`   system on
 ```)
@@ -323,8 +323,8 @@
   DBL          penalty-oriented
   2Y           5+Y, below INV
   2N           _Lebensohl_ (puppet to 3C)
-    = (DBL)
-      = system on
+    (DBL)
+      system on
     3C   forced
       PASS         below INV, C suit
       3Y below X   5+Y, below INV

--- a/lak-typst/1n.typ
+++ b/lak-typst/1n.typ
@@ -78,7 +78,7 @@
 #bt(```
   2S   5S, INV
   2N   4S, INV
-    * 3H   5H, accept
+*     3H   5H, accept
   3C   4S 5+C, GF
   3D   4S 5+D, GF
   3H   4H, INV
@@ -151,17 +151,17 @@
 
 #bt(```
 * 2S      { 5H 5 other, INV / 5S 5H, GF / 6+H, mild ST, splinter }
-    * 2N   waiting
-        * 3C       5H 5C, INV
-          3D       5H 5D, INV
-          3H       5S 5H, INV
-          3S       5S 5H, ST
-          3N 4CD   6+H mild ST, LMH splinter
-    * 3H   declines INV, 3H
-    * 4H   accepts INV, 3+H
+*     2N   waiting
+*         3C       5H 5C, INV
+*         3D       5H 5D, INV
+*         3H       5S 5H, INV
+*         3S       5S 5H, ST
+*         3N 4CD   6+H mild ST, LMH splinter
+*     3H   declines INV, 3H
+*     4H   accepts INV, 3+H
 * 2N      6+H, INV to game or slam
-    * 3H   declines INV
-    * 3S   accepts INV
+*     3H   declines INV
+*     3S   accepts INV
   3C      4+C, GF
   3D      4+D, GF
 * 3H      6+H, mild INV (needs 3H, MAX)
@@ -255,45 +255,45 @@
 
 #bt(```
   2N   MIN
-    * PASS   to play
-      3C     6+C, to play
-      3D     6C 4D, GF
-      3M     6+C, short M, GF
-      3N     6+C, light BAL ST
-      4C     6+C, short D, GF
-      4D     RKC C
-      4N     quant with 6C
+*     PASS   to play
+*     3C     6+C, to play
+*     3D     6C 4D, GF
+*     3M     6+C, short M, GF
+*     3N     6+C, light BAL ST
+*     4C     6+C, short D, GF
+*     4D     RKC C
+*     4N     quant with 6C
   3C   MAX
-    * PASS   to play
-      3D     6C 4D, GF
-      3M     6+C, short M, GF
-      3N     was invite to 3N
-      4C     6+C, short D, GF
-      4D     RKC C
-      4N     quant with 6C
-      5N     pick between 6C/6N
+*     PASS   to play
+*     3D     6C 4D, GF
+*     3M     6+C, short M, GF
+*     3N     was invite to 3N
+*     4C     6+C, short D, GF
+*     4D     RKC C
+*     4N     quant with 6C
+*     5N     pick between 6C/6N
 ```)
 
 === 1#N—2#N— <1N2N>
 
 #bt(```
   3C   rejects a D-based invite, may have MAX but 2D
-    * PASS   55 mm, no game
-      3D     to play
-      3M     6+D, short M, GF
-      3N     6+D, to play
-      4C     6+D, short C, GF
-      4D     RKC D
-      4N     quant with 6D
-      5N     choose 6N or 6D
+*     PASS   55 mm, no game
+*     3D     to play
+*     3M     6+D, short M, GF
+*     3N     6+D, to play
+*     4C     6+D, short C, GF
+*     4D     RKC D
+*     4N     quant with 6D
+*     5N     choose 6N or 6D
   3D   3+D, accepts 3D-based invite, with side stops
-    * PASS   55 mm, no game
-      3M     6+D, short M, GF
-      3N     6+D, was invite to game
-      4C     6+D, short C, GF
-      4D     RKC D
-      4N     quant with 6D
-      5N     choose 6N or 6D
+*     PASS   55 mm, no game
+*     3M     6+D, short M, GF
+*     3N     6+D, was invite to game
+*     4C     6+D, short C, GF
+*     4D     RKC D
+*     4N     quant with 6D
+*     5N     choose 6N or 6D
 ```)
 
 === 1#N—3#C— <1N3C>

--- a/lak-typst/1s.typ
+++ b/lak-typst/1s.typ
@@ -3,19 +3,19 @@
 == 1#S— <sec:1S>
 
 #bt(```
-  1N   7-11, no S fit
-  2m   11+, 5+m, unBAL
-  2H   11+, 5+H
-  2S   5-9, 3+S
-* 2N   11-12 or 17+, 3+S, F3S
-    * 3CDH   4+m, F1
-      3S     MIN, no side suit
-      4CDH   MAX, splinter
-      3N     MAX, 5S(332)
-      4S     MAX, 6S(322) or 7S(222)
-  3S   0-5, 4+S
-  3N   13-16, no S fit, BAL
-  4S   13-16, 3+S
+  1N     7-11, no S fit
+  2m     11+, 5+m, unBAL
+  2H     11+, 5+H
+  2S     5-9, 3+S
+* 2N     11-12 or 17+, 3+S, F3S
+*   3CDH   4+m, F1
+*   3S     MIN, no side suit
+*   4CDH   MAX, splinter
+*   3N     MAX, 5S(332)
+*   4S     MAX, 6S(322) or 7S(222)
+  3S     0-5, 4+S
+  3N     13-16, no S fit, BAL
+  4S     13-16, 3+S
 ```)
 
 === 1#S—(2#N minors)—

--- a/lak-typst/1s.typ
+++ b/lak-typst/1s.typ
@@ -53,7 +53,7 @@
 === 1#S—1#N— <1S1N>
 
 #bt(```
-  = (bid)
+  (bid)
     DBL   takeout, could be 6(331)
   PASS   10-13, BAL
   2C     4+C, unBAL
@@ -68,7 +68,7 @@
 === 1#S—2#C— <1S2C>
 
 #bt(```
-  = (bid)
+  (bid)
     DBL     penalty
     3C      3C, unBAL
     3 cue   4+C, shortness in opp's suit
@@ -114,7 +114,7 @@
 === 1#S—2#N <1S2N>
 
 #bt(```
-  = (bid)
+  (bid)
     DBL    shortness in their suit
     PASS   waiting
   3C       10-13

--- a/lak-typst/2c.typ
+++ b/lak-typst/2c.typ
@@ -7,11 +7,11 @@
   2H        8-11, 5+H, NF
   2S        8-11, 5+S, NF
 * 2N        puppet to 3C (to play or some 55 GF)
-    * 3C   forced
-        PASS   preemptive raise in C
-        3D     5S 5H, GF
-        3H     5H 5D, GF
-        3S     5S 5D, GF
+*     3C   forced
+*       PASS   preemptive raise in C
+*       3D     5S 5H, GF
+*       3H     5H 5D, GF
+*       3S     5S 5D, GF
 * 3CDH      11+, 6+ cards in the next higher suit, INV+
     transfer   decline INV (even with singleton)
     other      accept INV
@@ -29,13 +29,13 @@
 * 2H     4S or 4H
 * 2S     12-15, no 4-card major
 * 2N     14-15, stoppers in both majors, no 4-card major
-    * 3D   ST in C
-      3H   5H, GF
-      3S   5S, GF
+*     3D   ST in C
+*     3H   5H, GF
+*     3S   5S, GF
 * 3C     10-11, no 4-card major
-    * 3D   ST in C
-      3H   5H, GF
-      3S   5S, GF
+*     3D   ST in C
+*     3H   5H, GF
+*     3S   5S, GF
   3DHS   5-card suit, GF
 ```)
 

--- a/lak-typst/2d.typ
+++ b/lak-typst/2d.typ
@@ -4,7 +4,7 @@
 
 #bt(```
   2H        to play
-    * 2S   4315
+*     2S   4315
   2S        to play
   2N>2D2N   asks
   3C        to play
@@ -32,13 +32,13 @@ If opponents double 2#D, #rdbl asks for better major, #pass to request opener to
 
 #bt(```
 * 3C   MIN
-    * = 3D asks for a 3-card major
-        3H   4315
-        3S   3415
-        3N   44 majors
+*     3D asks for a 3-card major
+*       3H   4315
+*       3S   3415
+*       3N   44 majors
 * 3D   MAX, 44 majors, GF
-    * 3H   sets H for cues
-    * 3S   sets S for cues
+*     3H   sets H for cues
+*     3S   sets S for cues
 * 3H   MAX, 4315
 * 3S   MAX, 3415
 ```)

--- a/lak-typst/2h.typ
+++ b/lak-typst/2h.typ
@@ -7,7 +7,7 @@ Assume 6#plus#H unless NV vs. VUL.
 #bt(```
   2S   14+, 5+S, F1
   2N   14+, asks
-    = (bid)
+    (bid)
       * step 1   PASS
         step 2   DBL/RDBL
         step *   next bids
@@ -25,7 +25,7 @@ Assume 6#plus#H unless NV vs. VUL.
 #bt(```
   2S   F1
   2N   strong ask, F3H
-    = (bid)
+    (bid)
       PASS   good
       DBL    medium
       3S     bad

--- a/lak-typst/2h.typ
+++ b/lak-typst/2h.typ
@@ -8,9 +8,9 @@ Assume 6#plus#H unless NV vs. VUL.
   2S   14+, 5+S, F1
   2N   14+, asks
     (bid)
-      * step 1   PASS
-        step 2   DBL/RDBL
-        step *   next bids
+*       step 1   PASS
+*       step 2   DBL/RDBL
+*       step *   next bids
     3C   MIN, bad suit
     3D   MIN, good suit
     3H   MAX, bad suit

--- a/lak-typst/2n.typ
+++ b/lak-typst/2n.typ
@@ -29,7 +29,7 @@
     3N   5H
       4D   transfer to 4H
   3D   transfer to H { 5+H / 5H4S }
-    = 3H
+    3H
       3S   choose a game (indicating exactly 5H)
       3N   5H4S, no SI if no fit, NF
   3H   transfer to S, not 5S3-5H

--- a/lak-typst/2s.typ
+++ b/lak-typst/2s.typ
@@ -9,9 +9,9 @@ Assume 6#plus#S unless NV vs. VUL.
 #bt(```
   2N   14+, asks
     (bid)
-      * step 1   PASS
-        step 2   DBL/RDBL
-        step *   next bids
+*       step 1   PASS
+*       step 2   DBL/RDBL
+*       step *   next bids
     3C   MIN, bad suit
     3D   MIN, good suit
     3H   MAX, bad suit

--- a/lak-typst/2s.typ
+++ b/lak-typst/2s.typ
@@ -8,7 +8,7 @@ Assume 6#plus#S unless NV vs. VUL.
 
 #bt(```
   2N   14+, asks
-    = (bid)
+    (bid)
       * step 1   PASS
         step 2   DBL/RDBL
         step *   next bids

--- a/lak-typst/conventions.typ
+++ b/lak-typst/conventions.typ
@@ -7,13 +7,13 @@
 Not used after 1#C opening. It is on in some competitive situations (not if opponents bid after $Z$).
 
 #block[
-1#D—1#H—1#S— \
-1#D—1#H—1#N— \
-1#D—1#S—1#N— \
-1#H—1#S—1#N— \
-1#D—(1#H)—#dbl—1#S— \
-1#D—(1#H)—#dbl—1#N— \
-1#D—(1#S)—#dbl—1#N—
+  1#D—1#H—1#S— \
+  1#D—1#H—1#N— \
+  1#D—1#S—1#N— \
+  1#H—1#S—1#N— \
+  1#D—(1#H)—#dbl—1#S— \
+  1#D—(1#H)—#dbl—1#N— \
+  1#D—(1#S)—#dbl—1#N—
 ]
 
 #bt(```
@@ -26,7 +26,7 @@ Not used after 1#C opening. It is on in some competitive situations (not if oppo
   3C                  to play
 * 3D                  5Y5D, slam interest
 * 3Y                  6+ suit, slam interest
-    * 3N    to play
-      `*`   control for Y
+*     3N    to play
+*     `*`   control for Y
 * double jump shift   splinter for the last natural suit
 ```)

--- a/lak-typst/defences.typ
+++ b/lak-typst/defences.typ
@@ -129,13 +129,13 @@ Equal level conversion only over 1#M openings with o#M and #D, see #ref(<def:1M-
     3N           to play, no stopper
     4Y below X   5+Y, GF
   2Y             10--17, 5+ cards
-    * = (3X)
-      DBL   responsive, 10+, length in unbid suits, no support for Y
-    PASS      0--7
-    3X        strong raise in Y, GF
-    3Y        8--10, 3+ Y
-    3Z        5+ suit, F1
-    4 not Y   splinter
+*   (3X)
+*     DBL   responsive, 10+, length in unbid suits, no support for Y
+*   PASS      0--7
+*   3X        strong raise in Y, GF
+*   3Y        8--10, 3+ Y
+*   3Z        5+ suit, F1
+*   4 not Y   splinter
   2N             14--17, semiBAL, with stopper
 * 3Y below X     12--17, (5)6+ cards
 * 3Y above X     16+, very strong 6+ cards
@@ -186,7 +186,7 @@ Treat as weak 2$X$.
 
 #bt(```
   DBL     penalty-oriented
-    * bid   5S or 6+ card suit
+*     bid   5S or 6+ card suit
 * 4N      55+ mm
   other   natural
 ```)
@@ -195,7 +195,7 @@ Treat as weak 2$X$.
 
 #bt(```
   DBL     penalty-oriented
-    * bid   6+ card suit
+*     bid   6+ card suit
 * 4N      takeout
   other   natural
 ```)

--- a/lak-typst/defences.typ
+++ b/lak-typst/defences.typ
@@ -22,12 +22,12 @@ Equal level conversion only over 1#M openings with o#M and #D, see #ref(<def:1M-
 === (1#M)—#pass—(2#M)—#dbl—
 
 #bt(```
-  = (RDBL)
-    = system on
+  (RDBL)
+    system on
   2S           5+S, below INV
   2N           _Lebensohl_ (usually puppet to 3C)
-    = (DBL)
-      = system on
+    (DBL)
+      system on
     3C        usually forced
       PASS         below INV, C suit
       3X below M   5+X, below INV
@@ -56,8 +56,8 @@ Equal level conversion only over 1#M openings with o#M and #D, see #ref(<def:1M-
   DBL          responsive
   2S           5+S, below INV
   2N           _Lebensohl_ (usually puppet to 3C)
-    = (DBL)
-      = system on
+    (DBL)
+      system on
     3C        usually forced
       PASS         below INV, C suit
       3X below M   5+X, below INV
@@ -109,12 +109,12 @@ Equal level conversion only over 1#M openings with o#M and #D, see #ref(<def:1M-
 
 #bt(```
   DBL            { 12+, 3+ cards in unbid suits, shortness in X / 18+, 5+ strong suit = rebid suit / 18+, semiBAL, with stopper = rebid N }
-    = (RDBL)
-      = system on
+    (RDBL)
+      system on
     2Y           5+Y, below INV
     2N           _Lebensohl_ (usually puppet to 3C)
-      = (DBL)
-        = system on
+      (DBL)
+        system on
       3C        usually forced
         PASS         below INV, C suit
         3Y below X   5+Y, below INV

--- a/lak-typst/lib.typ
+++ b/lak-typst/lib.typ
@@ -87,7 +87,6 @@
 #let linkcol = black            // cross-reference underline colour
 #let fuindent = 4mm             // left indent of a followups sub-table
 #let hl(bid, desc) = (kind: "row", bid: bid, desc: desc, hl: true)
-#let hdr(body, hl: false) = (kind: "hdr", body: body, hl: hl)
 #let followups(..rows) = (kind: "fu", rows: rows.pos())
 
 // ---- Row-level diff styling, used only by the PR visual-diff pipeline ----
@@ -185,9 +184,6 @@
       let f = _row-fill(r.at("hl", default: false), r.at("status", default: none))
       cells.push(table.cell(fill: f, r.bid))
       cells.push(table.cell(fill: f, r.desc))
-    } else if type(r) == dictionary and r.kind == "hdr" {
-      let f = _row-fill(r.at("hl", default: false), r.at("status", default: none))
-      cells.push(table.cell(colspan: 2, fill: f, r.body))
     } else if type(r) == dictionary and r.kind == "fu" {
       cells.push(table.cell(
         colspan: 2, inset: (x: 0pt, y: 2.5pt),
@@ -225,7 +221,6 @@
 //     1H        8-11, denies 5+S    // 2+ spaces (or ` | `) split bid / meaning
 //   * 1N        12+, 5+H            // leading `*` highlights the row
 //       2N      asks                // deeper indent = followups (nested table)
-//     = over 1X                     // `= text` is a full-width header row
 //     DBL   { 6-7 = always / *8+, BAL = over 2X }   // `{…}` = dcases/dcasesr
 //   ```)
 //
@@ -406,9 +401,6 @@
   let hl = false
   if t.starts-with("* ") { hl = true; t = t.slice(2).trim() }
   let diffwrap = _diffwrap-for(status)
-  if t.starts-with("= ") {
-    return (kind: "hdr", body: diffwrap(_notation(t.slice(2).trim())), hl: hl, status: status)
-  }
   let bid = t
   let desc = ""
   if t.contains(" | ") {

--- a/lak-typst/lib.typ
+++ b/lak-typst/lib.typ
@@ -2,11 +2,11 @@
 // Mirrors the macros from the original LaTeX `preamble.tex`.
 
 // ---- Colours (dvipsnames, expressed as CMYK for fidelity) ----
-#let clubcol    = cmyk(91%, 0%, 88%, 12%)  // ForestGreen
+#let clubcol = cmyk(91%, 0%, 88%, 12%)  // ForestGreen
 #let diamondcol = cmyk(0%, 42%, 100%, 0%)  // YellowOrange
-#let heartcol   = cmyk(0%, 100%, 100%, 0%) // Red
+#let heartcol = cmyk(0%, 100%, 100%, 0%) // Red
 #let notrumpcol = cmyk(94%, 11%, 0%, 0%)   // Cerulean
-#let hlcol      = yellow.lighten(60%)      // yellow!40
+#let hlcol = yellow.lighten(60%)      // yellow!40
 
 // ---- Suit / bid symbols (\C \D \H \S \N and friends) ----
 #let C = text(fill: clubcol)[♣]
@@ -19,7 +19,7 @@
 // lowercase letters to cap-height capitals — feeding it already-uppercase
 // text leaves it unchanged (full-size), since true small caps only apply to
 // what would otherwise be lowercase.
-#let dbl  = smallcaps[dbl]
+#let dbl = smallcaps[dbl]
 #let rdbl = smallcaps[rdbl]
 #let pass = smallcaps[pass]
 
@@ -30,18 +30,16 @@
 #let MM = [MM]
 
 // ---- Small-caps signal names (\att \enc \disc) ----
-#let att  = smallcaps[att]
-#let enc  = smallcaps[enc]
+#let att = smallcaps[att]
+#let enc = smallcaps[enc]
 #let disc = smallcaps[disc]
 
 // ---- Ordinals (\nth{1} -> 1st ...) ----
 #let nth(n) = {
   let s = str(n)
-  let suf = if s.ends-with("11") or s.ends-with("12") or s.ends-with("13") { "th" }
-    else if s.ends-with("1") { "st" }
-    else if s.ends-with("2") { "nd" }
-    else if s.ends-with("3") { "rd" }
-    else { "th" }
+  let suf = if s.ends-with("11") or s.ends-with("12") or s.ends-with("13") { "th" } else if s.ends-with("1") {
+    "st"
+  } else if s.ends-with("2") { "nd" } else if s.ends-with("3") { "rd" } else { "th" }
   [#n#super[#suf]]
 }
 
@@ -63,20 +61,18 @@
   // A little vertical breathing room so multi-line brace rows do not crowd
   // their neighbours (single-line rows are unaffected).
   let h = gh + 5pt
-  box(baseline: 50%, height: h, stack(dir: ltr, spacing: 3pt,
-    box(height: h, align(horizon, brace)),
-    box(height: h, align(horizon, g)),
-  ))
+  box(baseline: 50%, height: h, stack(dir: ltr, spacing: 3pt, box(height: h, align(horizon, brace)), box(
+    height: h,
+    align(horizon, g),
+  )))
 }
 // dcases: single-column brace list of alternatives.
 #let dcases(..items) = _braced(
-  grid(columns: 1, row-gutter: 0.4em, align: left, ..items.pos())
+  grid(columns: 1, row-gutter: 0.4em, align: left, ..items.pos()),
 )
 // dcasesr: two-column brace, each row an (alternative, condition) pair.
 #let dcasesr(..pairs) = {
-  let cells = pairs.pos()
-    .map(p => (p.at(0), if p.len() > 1 { p.at(1) } else { [] }))
-    .flatten()
+  let cells = pairs.pos().map(p => (p.at(0), if p.len() > 1 { p.at(1) } else { [] })).flatten()
   _braced(grid(
     columns: (auto, auto), column-gutter: 1.2em, row-gutter: 0.4em, align: left,
     ..cells,
@@ -96,8 +92,8 @@
 // `bt` to rows whose source line starts with a `+ `/`- ` sentinel — see `_lines`.
 #let diffaddcol = rgb("#0000ff")
 #let diffdelcol = rgb("#cc0000")
-#let diffaddbg  = rgb("#eaf2ff")
-#let diffdelbg  = rgb("#fdeaea")
+#let diffaddbg = rgb("#eaf2ff")
+#let diffdelbg = rgb("#fdeaea")
 // Native `underline`/`strike` decorate per *text run*, not per line: a
 // superscript (e.g. the `+` in `5+H`, from `super[+]`) is its own run at a
 // shifted baseline and smaller size, so — even with an explicit `stroke:`
@@ -134,8 +130,7 @@
   if sz.width < _diff-line-width {
     box(width: sz.width, height: sz.height, {
       body
-      place(at, dy: if at == bottom { 1.5pt } else { 0pt },
-        line(length: sz.width, stroke: col + 0.6pt))
+      place(at, dy: if at == bottom { 1.5pt } else { 0pt }, line(length: sz.width, stroke: col + 0.6pt))
     })
   } else if at == bottom {
     // `offset:` is pinned rather than left `auto`: auto is computed per run
@@ -162,15 +157,11 @@
 // a highlighted row that changed still reads as "highlighted", not as an
 // unrelated addition/deletion.
 #let _hl-fill(status) = {
-  if status == "added" { diffaddbg }
-  else if status == "deleted" { diffdelbg }
-  else { hlcol }
+  if status == "added" { diffaddbg } else if status == "deleted" { diffdelbg } else { hlcol }
 }
 #let _row-fill(hl, status) = if hl { _hl-fill(status) } else { none }
 #let _diffwrap-for(status) = {
-  if status == "added" { diff-added }
-  else if status == "deleted" { diff-deleted }
-  else { body => body }
+  if status == "added" { diff-added } else if status == "deleted" { diff-deleted } else { body => body }
 }
 
 #let _render(rows) = {
@@ -186,7 +177,8 @@
       cells.push(table.cell(fill: f, r.desc))
     } else if type(r) == dictionary and r.kind == "fu" {
       cells.push(table.cell(
-        colspan: 2, inset: (x: 0pt, y: 2.5pt),
+        colspan: 2,
+        inset: (x: 0pt, y: 2.5pt),
         pad(left: fuindent, _render(r.rows)),
       ))
     }
@@ -234,13 +226,9 @@
 
 // Render one alphabetic word.
 #let _word(w) = {
-  if w == "PASS" { pass }
-  else if w == "DBL" { dbl }
-  else if w == "RDBL" { rdbl }
-  else if w == "X" { $X$ }
-  else if w == "Y" { $Y$ }
-  else if w == "Z" { $Z$ }
-  else if w.clusters().all(c => _suit.keys().contains(c)) {
+  if w == "PASS" { pass } else if w == "DBL" { dbl } else if w == "RDBL" { rdbl } else if w == "X" { $X$ } else if (
+    w == "Y"
+  ) { $Y$ } else if w == "Z" { $Z$ } else if w.clusters().all(c => _suit.keys().contains(c)) {
     w.clusters().map(c => _suit.at(c)).join()
   } else { [#w] }
 }
@@ -298,8 +286,9 @@
 //   X+1 / Y+2 / Z+3  — a Kickback-style step above a variable suit, as math.
 #let _notation(s) = {
   if s == "" { return [] }
-  if not (s.contains("`") or s.contains("_") or s.contains("](")
-      or s.contains("X+") or s.contains("Y+") or s.contains("Z+")) {
+  if not (
+    s.contains("`") or s.contains("_") or s.contains("](") or s.contains("X+") or s.contains("Y+") or s.contains("Z+")
+  ) {
     return _notation-core(s)
   }
   let out = []
@@ -307,10 +296,11 @@
   for m in s.matches(regex("`([^`]*)`|_([^_]*)_|\\[([^\\]]*)\\]\\(([^)]*)\\)|([XYZ])\\+([0-9]+)")) {
     if m.start > idx { out += _notation-core(s.slice(idx, m.start)) }
     let c = m.captures
-    if c.at(0) != none { out += [#(c.at(0))] }
-    else if c.at(1) != none { out += emph(_notation-core(c.at(1))) }
-    else if c.at(2) != none { out += link(label(c.at(3)), _notation-core(c.at(2))) }
-    else { out += _step(c.at(4), c.at(5)) }
+    if c.at(0) != none { out += [#(c.at(0))] } else if c.at(1) != none {
+      out += emph(_notation-core(c.at(1)))
+    } else if c.at(2) != none { out += link(label(c.at(3)), _notation-core(c.at(2))) } else {
+      out += _step(c.at(4), c.at(5))
+    }
     idx = m.end
   }
   if idx < s.len() { out += _notation-core(s.slice(idx)) }
@@ -329,11 +319,22 @@
   let sl = sep.len()
   while i < n {
     let c = s.at(i)
-    if c == "{" { depth += 1; cur += c; i += 1 }
-    else if c == "}" { depth -= 1; cur += c; i += 1 }
-    else if depth == 0 and s.slice(i, calc.min(i + sl, n)) == sep {
-      parts.push(cur); cur = ""; i += sl
-    } else { cur += c; i += 1 }
+    if c == "{" {
+      depth += 1
+      cur += c
+      i += 1
+    } else if c == "}" {
+      depth -= 1
+      cur += c
+      i += 1
+    } else if depth == 0 and s.slice(i, calc.min(i + sl, n)) == sep {
+      parts.push(cur)
+      cur = ""
+      i += sl
+    } else {
+      cur += c
+      i += 1
+    }
   }
   parts.push(cur)
   parts
@@ -396,23 +397,38 @@
 #let _parse-row(txt) = {
   let status = none
   let t = txt
-  if t.starts-with("+ ") { status = "added"; t = t.slice(2).trim(at: start) }
-  else if t.starts-with("- ") { status = "deleted"; t = t.slice(2).trim(at: start) }
+  if t.starts-with("+ ") {
+    status = "added"
+    t = t.slice(2).trim(at: start)
+  } else if t.starts-with("- ") {
+    status = "deleted"
+    t = t.slice(2).trim(at: start)
+  }
   let hl = false
-  if t.starts-with("* ") { hl = true; t = t.slice(2).trim() }
+  if t.starts-with("* ") {
+    hl = true
+    t = t.slice(2).trim()
+  }
   let diffwrap = _diffwrap-for(status)
   let bid = t
   let desc = ""
   if t.contains(" | ") {
     let p = t.split(" | ")
-    bid = p.at(0).trim(); desc = p.slice(1).join(" | ").trim()
+    bid = p.at(0).trim()
+    desc = p.slice(1).join(" | ").trim()
   } else {
     let m = t.match(regex("  +"))
-    if m != none { bid = t.slice(0, m.start).trim(); desc = t.slice(m.end).trim() }
-    else { bid = t.trim() }
+    if m != none {
+      bid = t.slice(0, m.start).trim()
+      desc = t.slice(m.end).trim()
+    } else { bid = t.trim() }
   }
   let lbl = none
-  if bid.contains(">") { let bp = bid.split(">"); bid = bp.at(0).trim(); lbl = bp.at(1).trim() }
+  if bid.contains(">") {
+    let bp = bid.split(">")
+    bid = bp.at(0).trim()
+    lbl = bp.at(1).trim()
+  }
   let bidc = _notation(bid)
   if lbl != none { bidc = link(label(lbl), bidc) }
   let descc = _maybe-braces(desc, status: status)

--- a/lak-typst/tools/btfmt.py
+++ b/lak-typst/tools/btfmt.py
@@ -8,8 +8,12 @@ independently within each group of sibling rows (i.e. rows sharing the same
 parent — the same units that render as one sub-table).
 
 It only ever touches the run of spaces between a bid and its description; bid
-text, `>label` links, `* ` highlight markers, `= header` rows, indentation and
-`{ … }` cells are preserved exactly.
+text, `>label` links, `= header` rows, indentation and `{ … }` cells are
+preserved exactly. A `* ` highlight marker is normalized to lead the line
+(before any indentation spaces) so highlighted rows line up in one column
+regardless of nesting depth — Typst's own parser doesn't require this and
+still accepts `*` anywhere after indentation, so this is purely a formatting
+convention.
 
 Usage (run from lak-typst/, or point paths at it from elsewhere):
     uv run --project tools tools/btfmt.py FILE.typ [FILE.typ …]  # rewrite in place
@@ -50,8 +54,12 @@ def parse_row(line: str) -> Row:
     lead = len(line) - len(line.lstrip(' '))
     body = line[lead:]
     hl = body.startswith('* ')
-    content = body[2:].lstrip(' ') if hl else body
-    prefix = ' ' * lead + ('* ' if hl else '')
+    if hl:
+        rest = body[2:].lstrip(' ')
+        lead += len(body) - 2 - len(rest)
+        body = rest
+    content = body
+    prefix = ('* ' if hl else '') + ' ' * lead
     col0 = len(prefix)
 
     if content.startswith('= '):


### PR DESCRIPTION
- PR diff images without creating new branches
- Remove bt = syntax
- General typst code formatting improvements
- Fix (hopefully all) conversion makes from latex